### PR TITLE
[ratelimit] fix: lua script rate limit consistency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,13 @@ services:
     environment:
       - USE_STATSD=false
       - LOG_LEVEL=debug
+      - REDIS_POOL_SIZE=100
       - REDIS_SOCKET_TYPE=tcp
       - REDIS_URL=redis:6379
       - RUNTIME_ROOT=/data
       - RUNTIME_SUBDIRECTORY=ratelimit
       - MEMCACHE_HOST_PORT=memcached:11211
+      - EXPIRATION_JITTER_MAX_SECONDS=0
 
 networks:
   ratelimit-network:

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -15,7 +15,7 @@ import (
 )
 
 type BaseRateLimiter struct {
-	timeSource                 utils.TimeSource
+	TimeSource                 utils.TimeSource
 	JitterRand                 *rand.Rand
 	ExpirationJitterMaxSeconds int64
 	cacheKeyGenerator          CacheKeyGenerator
@@ -46,7 +46,7 @@ func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
 	limits []*config.RateLimit, hitsAddend uint32) []CacheKey {
 	assert.Assert(len(request.Descriptors) == len(limits))
 	cacheKeys := make([]CacheKey, len(request.Descriptors))
-	now := this.timeSource.UnixNow()
+	now := this.TimeSource.UnixNow()
 	for i := 0; i < len(request.Descriptors); i++ {
 		// generateCacheKey() returns an empty string in the key if there is no limit
 		// so that we can keep the arrays all the same size.
@@ -142,7 +142,7 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatus(key string, limitInfo *
 func NewBaseRateLimit(timeSource utils.TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64,
 	localCache *freecache.Cache, nearLimitRatio float32, cacheKeyPrefix string, statsManager stats.Manager) *BaseRateLimiter {
 	return &BaseRateLimiter{
-		timeSource:                 timeSource,
+		TimeSource:                 timeSource,
 		JitterRand:                 jitterRand,
 		ExpirationJitterMaxSeconds: expirationJitterMaxSeconds,
 		cacheKeyGenerator:          NewCacheKeyGenerator(cacheKeyPrefix),
@@ -200,7 +200,7 @@ func (this *BaseRateLimiter) generateResponseDescriptorStatus(responseCode pb.Ra
 			Code:               responseCode,
 			CurrentLimit:       limit,
 			LimitRemaining:     limitRemaining,
-			DurationUntilReset: utils.CalculateReset(&limit.Unit, this.timeSource),
+			DurationUntilReset: utils.CalculateReset(&limit.Unit, this.TimeSource),
 		}
 	} else {
 		return &pb.RateLimitResponse_DescriptorStatus{

--- a/src/redis/driver.go
+++ b/src/redis/driver.go
@@ -30,6 +30,14 @@ type Client interface {
 	// @param args supplies the additional arguments.
 	PipeAppend(pipeline Pipeline, rcv interface{}, cmd string, args ...interface{}) Pipeline
 
+	// PipeScriptAppend append a script command onto the pipeline queue.
+	//
+	// @param pipeline supplies the queue for pending commands.
+	// @param rcv supplies receiver for the result.
+	// @param script supplies the script to append.
+	// @param args supplies the additional arguments.
+	PipeScriptAppend(pipeline Pipeline, rcv interface{}, script radix.EvalScript, args ...string) Pipeline
+
 	// PipeDo writes multiple commands to a Conn in
 	// a single write, then reads their responses in a single read. This reduces
 	// network delay into a single round-trip.

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -159,6 +159,10 @@ func (c *clientImpl) PipeAppend(pipeline Pipeline, rcv interface{}, cmd string, 
 	return append(pipeline, radix.FlatCmd(rcv, cmd, args...))
 }
 
+func (c *clientImpl) PipeScriptAppend(pipeline Pipeline, rcv interface{}, script radix.EvalScript, args ...string) Pipeline {
+	return append(pipeline, script.FlatCmd(rcv, nil, args))
+}
+
 func (c *clientImpl) PipeDo(ctx context.Context, pipeline Pipeline) error {
 	if c.implicitPipelining {
 		for _, action := range pipeline {

--- a/test/mocks/redis/redis.go
+++ b/test/mocks/redis/redis.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 
 	redis "github.com/envoyproxy/ratelimit/src/redis"
+	radix "github.com/mediocregopher/radix/v4"
 )
 
 // MockClient is a mock of Client interface.
@@ -128,4 +129,23 @@ func (m *MockClient) PipeDo(arg0 context.Context, arg1 redis.Pipeline) error {
 func (mr *MockClientMockRecorder) PipeDo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipeDo", reflect.TypeOf((*MockClient)(nil).PipeDo), arg0, arg1)
+}
+
+// PipeScriptAppend mocks base method.
+func (m *MockClient) PipeScriptAppend(arg0 redis.Pipeline, arg1 interface{}, arg2 radix.EvalScript, arg3 ...string) redis.Pipeline {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PipeScriptAppend", varargs...)
+	ret0, _ := ret[0].(redis.Pipeline)
+	return ret0
+}
+
+// PipeScriptAppend indicates an expected call of PipeScriptAppend.
+func (mr *MockClientMockRecorder) PipeScriptAppend(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipeScriptAppend", reflect.TypeOf((*MockClient)(nil).PipeScriptAppend), varargs...)
 }

--- a/test/mocks/redis/redis.go
+++ b/test/mocks/redis/redis.go
@@ -10,8 +10,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 
-	redis "github.com/envoyproxy/ratelimit/src/redis"
 	radix "github.com/mediocregopher/radix/v4"
+
+	redis "github.com/envoyproxy/ratelimit/src/redis"
 )
 
 // MockClient is a mock of Client interface.


### PR DESCRIPTION
We are trying to address https://github.com/goatapp/openapi-project/issues/82, guidance from https://redis.io/commands/incr/ and https://github.com/cristipufu/aspnetcore-redis-rate-limiting/blob/3ed4519428867e5f332ccf01791e4644e7843f96/src/RedisRateLimiting/FixedWindow/RedisFixedWindowManager.cs#L14-L36 revealed that there are subtle race conditions that can happen that impacts the consistency guarantees for the atomic counters.

As such this seeks to refactor this code to use a Lua script to manage the rate limit counters.