### PR TITLE
[ratelimit] chore: remove http/debug server

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,8 +682,6 @@ time="2020-09-10T17:22:35Z" level=debug msg="loading domain: messaging"
 time="2020-09-10T17:22:35Z" level=debug msg="loading descriptor: key=messaging.message_type_marketing"
 time="2020-09-10T17:22:35Z" level=debug msg="loading descriptor: key=messaging.message_type_marketing.to_number ratelimit={requests_per_unit=5, unit=DAY}"
 time="2020-09-10T17:22:35Z" level=debug msg="loading descriptor: key=messaging.to_number ratelimit={requests_per_unit=100, unit=DAY}"
-time="2020-09-10T17:21:55Z" level=warning msg="Listening for debug on ':6070'"
-time="2020-09-10T17:21:55Z" level=warning msg="Listening for HTTP on ':8080'"
 time="2020-09-10T17:21:55Z" level=debug msg="waiting for runtime update"
 time="2020-09-10T17:21:55Z" level=warning msg="Listening for gRPC on ':8081'"
 ```
@@ -701,8 +699,6 @@ Output example:
 {"@message":"loading descriptor: key=messaging.message_type_marketing","@timestamp":"2020-09-10T17:22:44.926019315Z","level":"debug"}
 {"@message":"loading descriptor: key=messaging.message_type_marketing.to_number ratelimit={requests_per_unit=5, unit=DAY}","@timestamp":"2020-09-10T17:22:44.926037174Z","level":"debug"}
 {"@message":"loading descriptor: key=messaging.to_number ratelimit={requests_per_unit=100, unit=DAY}","@timestamp":"2020-09-10T17:22:44.926048993Z","level":"debug"}
-{"@message":"Listening for debug on ':6070'","@timestamp":"2020-09-10T17:22:44.926113905Z","level":"warning"}
-{"@message":"Listening for gRPC on ':8081'","@timestamp":"2020-09-10T17:22:44.926182006Z","level":"warning"}
 {"@message":"Listening for HTTP on ':8080'","@timestamp":"2020-09-10T17:22:44.926227031Z","level":"warning"}
 {"@message":"waiting for runtime update","@timestamp":"2020-09-10T17:22:44.926267808Z","level":"debug"}
 ```


### PR DESCRIPTION
Per the original https://github.com/goatapp/go-services/pull/7799 removing the HTTP/DEBUG servers as they conflict with our ECS infra. These are unneeded by us as we only use the GRPC server.