### PR TITLE
feat: replace logrus logger with goat logger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 COPY src src
 COPY script script
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
+RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/goatapp/ratelimit/src/service_cmd
 
 FROM alpine:3.18.5@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0 AS final
 RUN apk --no-cache add ca-certificates && apk --no-cache update

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -43,7 +43,8 @@ services:
       - USE_STATSD=true
       - STATSD_HOST=statsd
       - STATSD_PORT=9125
-      - LOG_LEVEL=debug
+      - LOG_FORMAT=console
+      - LOG_LEVEL=DEBUG
       - REDIS_SOCKET_TYPE=tcp
       - REDIS_URL=redis:6379
       - RUNTIME_ROOT=/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,8 @@ services:
       - ./examples:/data
     environment:
       - USE_STATSD=false
-      - LOG_LEVEL=debug
+      - LOG_FORMAT=console
+      - LOG_LEVEL=DEBUG
       - REDIS_POOL_SIZE=100
       - REDIS_SOCKET_TYPE=tcp
       - REDIS_URL=redis:6379

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/lyft/goruntime v0.3.0
 	github.com/lyft/gostats v0.4.12
 	github.com/mediocregopher/radix/v4 v4.1.4
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1
 	go.opentelemetry.io/otel v1.21.0
@@ -26,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
+	go.uber.org/zap v1.25.0
 	golang.org/x/net v0.19.0
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
@@ -45,15 +45,15 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
 	github.com/tilinna/clock v1.0.2 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/mod v0.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231127180814-3a041ad873d4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGn
 github.com/alicebob/miniredis/v2 v2.31.0 h1:ObEFUNlJwoIiyjxdrYF0QIDE7qXcLc7D3WpSH4c22PU=
 github.com/alicebob/miniredis/v2 v2.31.0/go.mod h1:UB/T2Uztp7MlFSDakaX1sTXUv5CASoprx0wulRT6HBg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 h1:N7oVaKyGp8bttX0bfZGmcGkjz7DLQXhAn3DNd3T0ous=
 github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -156,7 +158,11 @@ go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
+go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
+go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -168,8 +174,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
-golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -220,8 +224,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.10.0 h1:tvDr/iQoUqNdohiYm0LmmKcBk+q86lb9EprIUFhHHGg=
-golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/integration-test/docker-compose-integration-test.yml
+++ b/integration-test/docker-compose-integration-test.yml
@@ -45,7 +45,8 @@ services:
       - USE_STATSD=true
       - STATSD_HOST=statsd
       - STATSD_PORT=9125
-      - LOG_LEVEL=debug
+      - LOG_FORMAT=console
+      - LOG_LEVEL=DEBUG
       - REDIS_SOCKET_TYPE=tcp
       - REDIS_URL=redis:6379
       - RUNTIME_ROOT=/data

--- a/src/log/logger.go
+++ b/src/log/logger.go
@@ -77,15 +77,13 @@ const (
 	userAgentKey       = "user_agent"
 )
 
-var (
-	loggableGRPCMetadata = map[string]string{
-		"x-goat-correlation-id":  correlationIdKey,
-		"x-forwarded-for":        ipAddressKey,
-		"x-forwarded-user-agent": originUserAgentKey,
-		"x-request-id":           requestIdKey,
-		"user-agent":             userAgentKey,
-	}
-)
+var loggableGRPCMetadata = map[string]string{
+	"x-goat-correlation-id":  correlationIdKey,
+	"x-forwarded-for":        ipAddressKey,
+	"x-forwarded-user-agent": originUserAgentKey,
+	"x-request-id":           requestIdKey,
+	"user-agent":             userAgentKey,
+}
 
 // nolint: gochecknoinits
 func init() {

--- a/src/log/logger.go
+++ b/src/log/logger.go
@@ -1,0 +1,312 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	loggerSettingsJson = `{
+		"level": "debug",
+		"encoding": "console",
+		"outputPaths": ["stderr"],
+	  	"errorOutputPaths": ["stderr"],
+		"development": false,
+		"disableStacktrace": true,
+	  	"encoderConfig": {
+	    	"messageKey": "message",
+	    	"levelKey": "level",
+	    	"levelEncoder": "capital",
+			"timeKey": "timestamp",
+			"timeEncoder": "iso8601",
+			"callerKey": "caller",
+			"callerEncoder": "short",
+			"stacktraceKey": "stack"
+	  	}
+	}`
+)
+
+type LogLevel string
+
+const (
+	DEBUG LogLevel = "DEBUG"
+	ERROR LogLevel = "ERROR"
+	WARN  LogLevel = "WARN"
+	INFO  LogLevel = "INFO"
+)
+
+type LogFormat string
+
+const (
+	CONSOLE LogFormat = "console"
+	JSON    LogFormat = "json"
+)
+
+type Log struct {
+	Level      LogLevel
+	Time       time.Time
+	LoggerName string
+	Message    string
+	Caller     string
+	Stack      string
+}
+
+var (
+	contextParsers      []ContextParser
+	contextParsersMutex sync.RWMutex
+	l                   *zap.Logger
+)
+
+const (
+	correlationIdKey   = "correlation_id"
+	ipAddressKey       = "ip_address"
+	originUserAgentKey = "origin_user_agent"
+	pathKey            = "pathKey"
+	requestIdKey       = "request_id"
+	userAgentKey       = "user_agent"
+)
+
+var (
+	loggableGRPCMetadata = map[string]string{
+		"x-goat-correlation-id":  correlationIdKey,
+		"x-forwarded-for":        ipAddressKey,
+		"x-forwarded-user-agent": originUserAgentKey,
+		"x-request-id":           requestIdKey,
+		"user-agent":             userAgentKey,
+	}
+)
+
+// nolint: gochecknoinits
+func init() {
+	l = New(
+		LogFormat(os.Getenv("LOG_FORMAT")),
+		LogLevel(os.Getenv("LOG_LEVEL")),
+	)
+
+	RegisterContextParser(scopedFieldsContextParser)
+	RegisterContextParser(grpcContextLogParser)
+}
+
+func withStackTrace(fields []zapcore.Field) []zapcore.Field {
+	return append(fields, zap.Stack("stacktrace"))
+}
+
+type LogField struct {
+	Key   string
+	Value interface{}
+}
+
+type LogOptions struct {
+	Err     error
+	Fields  []LogField
+	Context context.Context
+}
+
+type LogOption func(*LogOptions)
+
+func newOptionFields(ctx context.Context, errOpts ...LogOption) []zapcore.Field {
+	var fields []zapcore.Field
+	opts := &LogOptions{}
+
+	var ctxOpts []LogOption
+
+	contextParsersMutex.RLock()
+	defer contextParsersMutex.RUnlock()
+
+	for _, parser := range contextParsers {
+		ctxOpts = append(ctxOpts, parser(ctx)...)
+	}
+
+	// nolint: gocritic
+	augmentedOpts := append(errOpts, ctxOpts...)
+
+	for _, option := range augmentedOpts {
+		option(opts)
+	}
+
+	for _, field := range opts.Fields {
+		fields = append(fields, zap.Reflect(field.Key, field.Value))
+	}
+
+	if opts.Err != nil {
+		fields = append(fields, zap.Error(opts.Err))
+	}
+
+	return fields
+}
+
+func WithValue(key string, value interface{}) LogOption {
+	return func(opts *LogOptions) {
+		opts.Fields = append(opts.Fields, LogField{
+			Key:   key,
+			Value: value,
+		})
+	}
+}
+
+func WithError(err error) LogOption {
+	return func(opts *LogOptions) {
+		opts.Err = err
+	}
+}
+
+func New(env LogFormat, logLevel LogLevel) *zap.Logger {
+	var cfg zap.Config
+	if err := json.Unmarshal([]byte(loggerSettingsJson), &cfg); err != nil {
+		panic(err)
+	}
+
+	if env == JSON {
+		cfg.Encoding = "json"
+	}
+
+	switch logLevel {
+	case DEBUG:
+		cfg.Level.SetLevel(zap.DebugLevel)
+	case ERROR:
+		cfg.Level.SetLevel(zap.ErrorLevel)
+	case WARN:
+		cfg.Level.SetLevel(zap.WarnLevel)
+	case INFO:
+		cfg.Level.SetLevel(zap.InfoLevel)
+	default:
+		cfg.Level.SetLevel(zap.InfoLevel)
+	}
+
+	logger, err := cfg.Build()
+	if err != nil {
+		panic(err)
+	}
+
+	l = logger.WithOptions(zap.AddCallerSkip(1))
+
+	return l
+}
+
+func Debug(ctx context.Context, msg string, opts ...LogOption) {
+	l.Debug(msg, newOptionFields(ctx, opts...)...)
+}
+
+func Info(ctx context.Context, msg string, opts ...LogOption) {
+	l.Info(msg, newOptionFields(ctx, opts...)...)
+}
+
+func Warn(ctx context.Context, msg string, opts ...LogOption) {
+	l.Warn(msg, newOptionFields(ctx, opts...)...)
+}
+
+func Error(ctx context.Context, msg string, opts ...LogOption) {
+	l.Error(msg, withStackTrace(newOptionFields(ctx, opts...))...)
+}
+
+func Fatal(ctx context.Context, msg string, opts ...LogOption) {
+	l.Fatal(msg, withStackTrace(newOptionFields(ctx, opts...))...)
+}
+
+func Panic(ctx context.Context, msg string, opts ...LogOption) {
+	l.Panic(msg, withStackTrace(newOptionFields(ctx, opts...))...)
+}
+
+func DPanic(ctx context.Context, msg string, opts ...LogOption) {
+	l.DPanic(msg, withStackTrace(newOptionFields(ctx, opts...))...)
+}
+
+func Sync() {
+	_ = l.Sync()
+}
+
+type scopedFieldsCtxKey struct{}
+
+func (k *scopedFieldsCtxKey) String() string { return "go-services/common/log scoped fields" }
+
+// AddField adds a field to be logged along with the context. If the field already exists, it will be overwritten.
+func AddField(ctx context.Context, key string, value interface{}) context.Context {
+	if key == "" {
+		return ctx
+	}
+
+	return AddFields(ctx, LogField{Key: key, Value: value})
+}
+
+// AddFields adds fields to be logged along with the context. If a field already exists, it will be overwritten.
+func AddFields(ctx context.Context, fields ...LogField) context.Context {
+	if len(fields) == 0 {
+		return ctx
+	}
+
+	var fieldMap map[string]interface{}
+
+	if existing, ok := ctx.Value(scopedFieldsCtxKey{}).(map[string]interface{}); ok {
+		fieldMap = maps.Clone(existing)
+	} else {
+		fieldMap = make(map[string]interface{})
+	}
+
+	for _, field := range fields {
+		fieldMap[field.Key] = field.Value
+	}
+
+	return context.WithValue(ctx, scopedFieldsCtxKey{}, fieldMap)
+}
+
+func grpcContextLogParser(ctx context.Context) []LogOption {
+	var logOptions []LogOption
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return logOptions
+	}
+
+	for mdKey, logKey := range loggableGRPCMetadata {
+		if mdVals := md.Get(mdKey); len(mdVals) > 0 {
+			logOptions = append(logOptions, WithValue(logKey, mdVals[0]))
+		}
+	}
+
+	method, ok := grpc.Method(ctx)
+	if ok {
+		// Method looks something like - goat.protos.Api/Rpc
+		splitMethod := strings.Split(method, ".")
+
+		// Get the last value - Api/Rpc
+		method = splitMethod[len(splitMethod)-1]
+		// Do a char replacement to . to properly index - Api.Rpc
+		method = strings.ReplaceAll(method, "/", ".")
+
+		logOptions = append(logOptions, WithValue(pathKey, method))
+	}
+
+	return logOptions
+}
+
+func scopedFieldsContextParser(ctx context.Context) []LogOption {
+	var opts []LogOption
+
+	if userFieldMap, ok := ctx.Value(scopedFieldsCtxKey{}).(map[string]interface{}); ok {
+		for key, value := range userFieldMap {
+			opts = append(opts, WithValue(key, value))
+		}
+	}
+
+	return opts
+}
+
+type ContextParser func(ctx context.Context) []LogOption
+
+func RegisterContextParser(f ContextParser) {
+	contextParsersMutex.Lock()
+	defer contextParsersMutex.Unlock()
+
+	contextParsers = append(contextParsers, f)
+}

--- a/src/provider/file_provider.go
+++ b/src/provider/file_provider.go
@@ -1,14 +1,15 @@
 package provider
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
 	"github.com/lyft/goruntime/loader"
 	gostats "github.com/lyft/gostats"
-	logger "github.com/sirupsen/logrus"
 
 	"github.com/goatapp/ratelimit/src/config"
+	logger "github.com/goatapp/ratelimit/src/log"
 	"github.com/goatapp/ratelimit/src/settings"
 	"github.com/goatapp/ratelimit/src/stats"
 )
@@ -37,9 +38,9 @@ func (p *FileProvider) watch() {
 		p.sendEvent()
 		// No exit right now.
 		for {
-			logger.Debugf("waiting for runtime update")
+			logger.Debug(context.Background(), "waiting for runtime update")
 			<-p.runtimeUpdateEvent
-			logger.Debugf("got runtime update and reloading config")
+			logger.Debug(context.Background(), "got runtime update and reloading config")
 			p.sendEvent()
 		}
 	}()

--- a/src/server/health.go
+++ b/src/server/health.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,10 +11,10 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	logger "github.com/sirupsen/logrus"
-
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	logger "github.com/goatapp/ratelimit/src/log"
 )
 
 type HealthChecker struct {
@@ -97,7 +98,8 @@ func (hc *HealthChecker) Fail(componentName string) error {
 		hc.grpc.SetServingStatus(hc.name, healthpb.HealthCheckResponse_NOT_SERVING)
 	} else {
 		errorText := fmt.Sprintf("Invalid component: %s", componentName)
-		logger.Errorf(errorText)
+		logger.Error(context.Background(), errorText)
+
 		return errors.New(errorText)
 	}
 	return nil
@@ -118,8 +120,10 @@ func (hc *HealthChecker) Ok(componentName string) error {
 		}
 	} else {
 		errorText := fmt.Sprintf("Invalid component: %s", componentName)
-		logger.Errorf(errorText)
-		return errors.New(errorText)
+		err := errors.New(errorText)
+		logger.Error(context.Background(), errorText)
+
+		return err
 	}
 
 	return nil

--- a/src/server/tls.go
+++ b/src/server/tls.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 
-	logger "github.com/sirupsen/logrus"
+	logger "github.com/goatapp/ratelimit/src/log"
 )
 
 func verifyClient(clientCAPool *x509.CertPool, clientSAN string) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -25,7 +27,7 @@ func verifyClient(clientCAPool *x509.CertPool, clientSAN string) func(rawCerts [
 			}
 			_, err := certs[0].Verify(opts)
 			if err != nil {
-				logger.Warnf("error validating client: %s", err.Error())
+				logger.Warn(context.Background(), fmt.Sprintf("error validating client: %s", err.Error()))
 				return err
 			}
 		}

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -42,9 +42,6 @@ type Settings struct {
 	GrpcClientTlsCACert string `envconfig:"GRPC_CLIENT_TLS_CACERT" default:""`
 	// GrpcClientTlsSAN is the SAN to validate from the client cert during mTLS auth
 	GrpcClientTlsSAN string `envconfig:"GRPC_CLIENT_TLS_SAN" default:""`
-	// Logging settings
-	LogLevel  string `envconfig:"LOG_LEVEL" default:"WARN"`
-	LogFormat string `envconfig:"LOG_FORMAT" default:"text"`
 
 	// Rate limit configuration
 	// ConfigType is the method of configuring rate limits. Possible values "FILE", "GRPC_XDS_SOTW".

--- a/src/stats/manager_impl.go
+++ b/src/stats/manager_impl.go
@@ -1,12 +1,13 @@
 package stats
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	gostats "github.com/lyft/gostats"
-	logger "github.com/sirupsen/logrus"
 
+	logger "github.com/goatapp/ratelimit/src/log"
 	"github.com/goatapp/ratelimit/src/settings"
 	"github.com/goatapp/ratelimit/src/utils"
 )
@@ -46,7 +47,7 @@ func (this *ManagerImpl) GetStatsStore() gostats.Store {
 // @return new stats.
 func (this *ManagerImpl) NewStats(key string) RateLimitStats {
 	ret := RateLimitStats{}
-	logger.Debugf("Creating stats for key: '%s'", key)
+	logger.Debug(context.Background(), fmt.Sprintf("Creating stats for key: '%s'", key))
 	ret.Key = key
 	key = utils.SanitizeStatName(key)
 	ret.TotalHits = this.rlStatsScope.NewCounter(key + ".total_hits")

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -88,7 +89,7 @@ func TestGetResponseStatusEmptyKey(t *testing.T) {
 	defer controller.Finish()
 	sm := mockstats.NewMockStatManager(stats.NewStore(stats.NewNullSink(), false))
 	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8, "", sm)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("", nil, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "", nil, false, 1)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 }
@@ -105,7 +106,7 @@ func TestGetResponseStatusOverLimitWithLocalCache(t *testing.T) {
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 4, 5)
 	// As `isOverLimitWithLocalCache` is passed as `true`, immediate response is returned with no checks of the limits.
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, true, 2)
 	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -128,7 +129,7 @@ func TestGetResponseStatusOverLimitWithLocalCacheShadowMode(t *testing.T) {
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 4, 5)
 	// As `isOverLimitWithLocalCache` is passed as `true`, immediate response is returned with no checks of the limits.
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, true, 2)
 	// Limit is reached, but response is still OK due to ShadowMode
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
@@ -151,7 +152,7 @@ func TestGetResponseStatusOverLimit(t *testing.T) {
 	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, localCache, 0.8, "", sm)
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 7, 4, 5)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, false, 1)
 	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -177,7 +178,7 @@ func TestGetResponseStatusOverLimitShadowMode(t *testing.T) {
 	// Key is in shadow_mode: true
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 7, 4, 5)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, false, 1)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -199,7 +200,7 @@ func TestGetResponseStatusBelowLimit(t *testing.T) {
 	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "", sm)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 9, 10)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, false, 1)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(4), responseStatus.GetLimitRemaining())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -220,7 +221,7 @@ func TestGetResponseStatusBelowLimitShadowMode(t *testing.T) {
 	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "", sm)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 9, 10)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus(context.Background(), "key", limitInfo, false, 1)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(4), responseStatus.GetLimitRemaining())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())

--- a/test/mocks/stats/manager.go
+++ b/test/mocks/stats/manager.go
@@ -1,9 +1,11 @@
 package stats
 
 import (
+	"context"
+	"fmt"
 	gostats "github.com/lyft/gostats"
-	logger "github.com/sirupsen/logrus"
 
+	logger "github.com/goatapp/ratelimit/src/log"
 	"github.com/goatapp/ratelimit/src/stats"
 	"github.com/goatapp/ratelimit/src/utils"
 )
@@ -35,7 +37,7 @@ func (m *MockStatManager) NewServiceStats() stats.ServiceStats {
 
 func (m *MockStatManager) NewStats(key string) stats.RateLimitStats {
 	ret := stats.RateLimitStats{}
-	logger.Debugf("outputing test gostats %s", key)
+	logger.Debug(context.Background(), fmt.Sprintf("outputting test gostats %s", key))
 	ret.Key = key
 	key = utils.SanitizeStatName(key)
 	ret.TotalHits = m.store.NewCounter(key + ".total_hits")

--- a/test/mocks/stats/manager.go
+++ b/test/mocks/stats/manager.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"context"
 	"fmt"
+
 	gostats "github.com/lyft/gostats"
 
 	logger "github.com/goatapp/ratelimit/src/log"


### PR DESCRIPTION
We are missing the QOL of changes by not making use of the goat logger including things such as the `request-id` logging for log correlation in Grafana.