### PR TITLE
make cache keys fixed

### DIFF
--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -130,12 +130,15 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatus(ctx context.Context, ke
 		}
 	}
 
-	// If the limit is in ShadowMode, it should be always return OK
-	if isOverLimit && limitInfo.limit.ShadowMode {
-		logger.Debug(ctx, fmt.Sprintf("Limit with key %s, is in shadow_mode", limitInfo.limit.FullKey))
-		responseDescriptorStatus.Code = pb.RateLimitResponse_OK
-		// Increase shadow mode stats if the limit was actually over the limit
-		this.increaseShadowModeStats(isOverLimitWithLocalCache, limitInfo, hitsAddend)
+	if isOverLimit {
+		if limitInfo.limit.ShadowMode {
+			logger.Debug(ctx, fmt.Sprintf("Limit with key %s, is in shadow_mode", limitInfo.limit.FullKey))
+			responseDescriptorStatus.Code = pb.RateLimitResponse_OK
+			// Increase shadow mode stats if the limit was actually over the limit
+			this.increaseShadowModeStats(isOverLimitWithLocalCache, limitInfo, hitsAddend)
+		} else {
+			logger.Debug(ctx, fmt.Sprintf("Limit with key %s, is over_limit", limitInfo.limit.FullKey))
+		}
 	}
 
 	return responseDescriptorStatus

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -48,11 +48,11 @@ func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
 	limits []*config.RateLimit, hitsAddend uint32) []CacheKey {
 	assert.Assert(len(request.Descriptors) == len(limits))
 	cacheKeys := make([]CacheKey, len(request.Descriptors))
-	now := this.TimeSource.UnixNow()
+
 	for i := 0; i < len(request.Descriptors); i++ {
 		// generateCacheKey() returns an empty string in the key if there is no limit
 		// so that we can keep the arrays all the same size.
-		cacheKeys[i] = this.cacheKeyGenerator.GenerateCacheKey(request.Domain, request.Descriptors[i], limits[i], now)
+		cacheKeys[i] = this.cacheKeyGenerator.GenerateCacheKey(request.Domain, request.Descriptors[i], limits[i])
 		// Increase statistics for limits hit by their respective requests.
 		if limits[i] != nil {
 			limits[i].Stats.TotalHits.Add(uint64(hitsAddend))

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -23,7 +23,13 @@ import (
 	"github.com/goatapp/ratelimit/src/utils"
 )
 
-var script = `local expires_at = tonumber(redis.call("get", ARGV[2]))
+var script = `
+-- ARGV[1] = entry key
+-- ARGV[2] = expiration entry key
+-- ARGV[3] = expiration time
+-- ARGV[4] = current time
+-- ARGV[5] = increment count
+local expires_at = tonumber(redis.call("get", ARGV[2]))
 
 if not expires_at or expires_at < tonumber(ARGV[4]) then
 	-- this is either a brand new window,

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -500,7 +500,7 @@ func testBasicBaseConfig(s settings.Settings) func(*testing.T) {
 			&pb.RateLimitResponse{
 				OverallCode: pb.RateLimitResponse_OK,
 				Statuses: []*pb.RateLimitResponse_DescriptorStatus{
-					newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 48, durRemaining),
+					newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 49, durRemaining),
 				},
 			},
 			response)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -500,7 +500,7 @@ func testBasicBaseConfig(s settings.Settings) func(*testing.T) {
 			&pb.RateLimitResponse{
 				OverallCode: pb.RateLimitResponse_OK,
 				Statuses: []*pb.RateLimitResponse_DescriptorStatus{
-					newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 49, durRemaining),
+					newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 48, durRemaining),
 				},
 			},
 			response)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -516,7 +516,7 @@ func testBasicBaseConfig(s settings.Settings) func(*testing.T) {
 			}
 
 			return false
-		}, fmt.Sprintf("These two protobuf messages are not equal:\nexpected: %v\nactual:  %v", expectedResponse_48, response))
+		}, fmt.Sprintf("These protobuf messages are not equal:\nexpected_1: %v\n or expected_2: %v\n actual:  %v", expectedResponse_48, expectedResponse_49, response))
 		assert.NoError(err)
 
 		// store.NewCounter returns the existing counter.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -510,7 +510,7 @@ func testBasicBaseConfig(s settings.Settings) func(*testing.T) {
 			},
 		}
 
-		assert.Condition(func() {
+		assert.Condition(func() bool {
 			if proto.Equal(expectedResponse_48, response) || proto.Equal(expectedResponse_49, response) {
 				return true
 			}

--- a/test/redis/fixed_cache_impl_test.go
+++ b/test/redis/fixed_cache_impl_test.go
@@ -60,7 +60,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 			cache = redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false)
 		}
 
-		timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
+		timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 		var clientUsed *mock_redis.MockClient
 		if usePerSecondRedis {
 			clientUsed = perSecondClient
@@ -68,7 +68,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 			clientUsed = client
 		}
 
-		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value_1234", "domain_key_value_1234:expires", "1235", "1234",
+		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value", "domain_key_value:expires", "1235", "1234",
 			"1").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
 		clientUsed.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -84,8 +84,8 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
 
 		clientUsed = client
-		timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key2_value2_subkey2_subvalue2_1200", "domain_key2_value2_subkey2_subvalue2_1200:expires", "1294", "1234",
+		timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key2_value2_subkey2_subvalue2", "domain_key2_value2_subkey2_subvalue2:expires", "1294", "1234",
 			"1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
 		clientUsed.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -111,10 +111,10 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		assert.Equal(uint64(0), limits[1].Stats.WithinLimit.Value())
 
 		clientUsed = client
-		timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(7)
-		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key3_value3_997200", "domain_key3_value3_997200:expires",
+		timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(6)
+		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key3_value3", "domain_key3_value3:expires",
 			"1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
-		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key3_value3_subkey3_subvalue3_950400", "domain_key3_value3_subkey3_subvalue3_950400:expires",
+		clientUsed.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key3_value3_subkey3_subvalue3", "domain_key3_value3_subkey3_subvalue3:expires",
 			"1086400", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
 		clientUsed.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -197,7 +197,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(5)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
@@ -222,7 +222,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 
 	// Test Near Limit Stats. At Near Limit Ratio, still OK
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	assert.Equal(
@@ -241,7 +241,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 
 	// Test Over limit stats
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	assert.Equal(
@@ -260,7 +260,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 
 	// Test Over limit stats with local cache
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").Times(0)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").Times(0)
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: utils.CalculateReset(&limits[0].Limit.Unit, timeSource)},
@@ -288,8 +288,8 @@ func TestNearLimit(t *testing.T) {
 	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
-	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
@@ -309,8 +309,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
 
 	// Test Near Limit Stats. At Near Limit Ratio, still OK
-	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	assert.Equal(
@@ -325,8 +325,8 @@ func TestNearLimit(t *testing.T) {
 
 	// Test Near Limit Stats. We went OVER_LIMIT, but the near_limit counter only increases
 	// when we are near limit, not after we have passed the limit.
-	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	assert.Equal(
@@ -341,8 +341,8 @@ func TestNearLimit(t *testing.T) {
 
 	// Now test hitsAddend that is greater than 1
 	// All of it under limit, under near limit
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5_1234", "domain_key5_value5_1234:expires", "1235", "1234", "3").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5", "domain_key5_value5:expires", "1235", "1234", "3").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key5", "value5"}}}, 3)
@@ -357,8 +357,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(3), limits[0].Stats.WithinLimit.Value())
 
 	// All of it under limit, some over near limit
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key6_value6_1234", "domain_key6_value6_1234:expires", "1235", "1234", "2").SetArg(1, []int64{7, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key6_value6", "domain_key6_value6:expires", "1235", "1234", "2").SetArg(1, []int64{7, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key6", "value6"}}}, 2)
@@ -373,8 +373,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(2), limits[0].Stats.WithinLimit.Value())
 
 	// All of it under limit, all of it over near limit
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key7_value7_1234", "domain_key7_value7_1234:expires", "1235", "1234", "3").SetArg(1, []int64{19, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key7_value7", "domain_key7_value7:expires", "1235", "1234", "3").SetArg(1, []int64{19, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key7", "value7"}}}, 3)
@@ -389,8 +389,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(3), limits[0].Stats.WithinLimit.Value())
 
 	// Some of it over limit, all of it over near limit
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key8_value8_1234", "domain_key8_value8_1234:expires", "1235", "1234", "3").SetArg(1, []int64{22, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key8_value8", "domain_key8_value8:expires", "1235", "1234", "3").SetArg(1, []int64{22, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key8", "value8"}}}, 3)
@@ -405,8 +405,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(0), limits[0].Stats.WithinLimit.Value())
 
 	// Some of it in all three places
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key9_value9_1234", "domain_key9_value9_1234:expires", "1235", "1234", "7").SetArg(1, []int64{22, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key9_value9", "domain_key9_value9:expires", "1235", "1234", "7").SetArg(1, []int64{22, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key9", "value9"}}}, 7)
@@ -421,8 +421,8 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(uint64(0), limits[0].Stats.WithinLimit.Value())
 
 	// all of it over limit
-	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key10_value10_1234", "domain_key10_value10_1234:expires", "1235", "1234", "3").SetArg(1, []int64{30, 1}).DoAndReturn(pipeScriptAppend)
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key10_value10", "domain_key10_value10:expires", "1235", "1234", "3").SetArg(1, []int64{30, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key10", "value10"}}}, 3)
@@ -451,7 +451,7 @@ func TestRedisWithJitter(t *testing.T) {
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
 	jitterSource.EXPECT().Int63().Return(int64(100))
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value_1234", "domain_key_value_1234:expires", "1335", "1234", "1").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value", "domain_key_value:expires", "1335", "1234", "1").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
@@ -482,7 +482,7 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
@@ -507,7 +507,7 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 
 	// Test Near Limit Stats. At Near Limit Ratio, still OK
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	assert.Equal(
@@ -526,7 +526,7 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 
 	// Test Over limit stats
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{16, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	// The result should be OK since limit is in ShadowMode
@@ -547,9 +547,9 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 
 	// Test Over limit stats with local cache
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(4)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").Times(0)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").Times(0)
 	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(),
-		"EXPIRE", "domain_key4_value4_997200", int64(3600)).Times(0)
+		"EXPIRE", "domain_key4_value4", int64(3600)).Times(0)
 
 	// The result should be OK since limit is in ShadowMode
 	assert.Equal(
@@ -587,7 +587,7 @@ func TestRedisTracer(t *testing.T) {
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(4)
 
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value_1234", "domain_key_value_1234:expires", "1235", "1234", "1").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key_value", "domain_key_value:expires", "1235", "1234", "1").SetArg(1, []int64{5, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
@@ -616,10 +616,10 @@ func TestOverLimitWithStopCacheKeyIncrementWhenOverlimitConfig(t *testing.T) {
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(7)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4_997200").SetArg(1, uint32(11)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5_997200").SetArg(1, uint32(11)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5_997200", "domain_key5_value5_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4").SetArg(1, uint32(11)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5").SetArg(1, uint32(11)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5", "domain_key5_value5:expires", "1003600", "1000000", "1").SetArg(1, []int64{11, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}, {{"key5", "value5"}}}, 1)
@@ -651,10 +651,10 @@ func TestOverLimitWithStopCacheKeyIncrementWhenOverlimitConfig(t *testing.T) {
 
 	// Test Near Limit Stats. At Near Limit Ratio, still OK
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(7)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4_997200").SetArg(1, uint32(13)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5_997200").SetArg(1, uint32(13)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5_997200", "domain_key5_value5_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4").SetArg(1, uint32(13)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5").SetArg(1, uint32(13)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5", "domain_key5_value5:expires", "1003600", "1000000", "1").SetArg(1, []int64{13, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	assert.Equal(
@@ -679,10 +679,10 @@ func TestOverLimitWithStopCacheKeyIncrementWhenOverlimitConfig(t *testing.T) {
 
 	// Test one key is reaching to the Overlimit threshold
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(7)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4_997200").SetArg(1, uint32(14)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5_997200").SetArg(1, uint32(14)).DoAndReturn(pipeAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4_997200", "domain_key4_value4_997200:expires", "1003600", "1000000", "0").SetArg(1, []int64{14, 1}).DoAndReturn(pipeScriptAppend)
-	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5_997200", "domain_key5_value5_997200:expires", "1003600", "1000000", "1").SetArg(1, []int64{14, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key4_value4").SetArg(1, uint32(14)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeAppend(gomock.Any(), gomock.Any(), "GET", "domain_key5_value5").SetArg(1, uint32(14)).DoAndReturn(pipeAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key4_value4", "domain_key4_value4:expires", "1003600", "1000000", "0").SetArg(1, []int64{14, 1}).DoAndReturn(pipeScriptAppend)
+	client.EXPECT().PipeScriptAppend(gomock.Any(), gomock.Any(), gomock.Any(), "domain_key5_value5", "domain_key5_value5:expires", "1003600", "1000000", "1").SetArg(1, []int64{14, 1}).DoAndReturn(pipeScriptAppend)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	assert.Equal(


### PR DESCRIPTION
Remove timestamp suffix from cache key generation to have more predictable keys.