### PR TITLE
fix: replace removed otelgrpc interceptors with NewServerHandler

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -225,10 +225,9 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 	grpcOptions := []grpc.ServerOption{
 		keepaliveOpt,
 		grpc.ChainUnaryInterceptor(
-			s.GrpcUnaryInterceptor, // chain otel interceptor after the input interceptor
-			otelgrpc.UnaryServerInterceptor(),
+			s.GrpcUnaryInterceptor,
 		),
-		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	}
 	if s.GrpcServerUseTLS {
 		grpcServerTlsConfig := s.GrpcServerTlsConfig


### PR DESCRIPTION
otelgrpc.UnaryServerInterceptor() and StreamServerInterceptor() were removed in otelgrpc v0.56.0. Use grpc.StatsHandler(otelgrpc.NewServerHandler()) which is the supported replacement.